### PR TITLE
✨ Feat: 회원가입 단계별 진행 상태 및 필드 검증 로직 개선 (누락 커밋 복구) #26

### DIFF
--- a/lib/features/auth/data/model/sign_up_process_state.dart
+++ b/lib/features/auth/data/model/sign_up_process_state.dart
@@ -39,6 +39,26 @@ class SignUpProcessState with _$SignUpProcessState {
       ? '$selectedFirstMbtiLetter$selectedSecondMbtiLetter$selectedThirdMbtiLetter$selectedFourthMbtiLetter'
       : null;
 
+  get unwritten {
+    final fields = {
+      'selectedYear': selectedYear,
+      'selectedHeight': selectedHeight,
+      'selectedJob': selectedJob,
+      'selectedLocation': selectedLocation,
+      'selectedEducation': selectedEducation,
+      'mbti': mbti,
+      'selectedSmoking': selectedSmoking,
+      'selectedDrinking': selectedDrinking,
+      'selectedReligion': selectedReligion,
+      'selectedHobbies': selectedHobbies.isEmpty ? null : selectedHobbies,
+    };
+
+    return fields.entries
+        .where((entry) => entry.value == null)
+        .map((entry) => entry.key)
+        .toList();
+  }
+
   get isSecondStepCompleted =>
       selectedYear != null &&
       selectedHeight != null &&

--- a/lib/features/auth/domain/provider/sign_up_process_provider.dart
+++ b/lib/features/auth/domain/provider/sign_up_process_provider.dart
@@ -10,11 +10,46 @@ class SignUpProcess extends _$SignUpProcess {
   @override
   SignUpProcessState build() => const SignUpProcessState();
   void nextStep(BuildContext context) {
-    if (state.currentStep == 10) {
+    // 순서대로 처리할 필드 정의
+    final requiredFieldsOrder = [
+      'selectedYear',
+      'selectedHeight',
+      'selectedJob',
+      'selectedLocation',
+      'selectedEducation',
+      'mbti',
+      'selectedSmoking',
+      'selectedDrinking',
+      'selectedReligion',
+      'selectedHobbies',
+    ];
+
+    // 현재 상태에서 입력되지 않은 필드 필터링
+    final unwrittenFields = state.unwritten
+        .where((field) => requiredFieldsOrder.contains(field))
+        .toList();
+
+    if (unwrittenFields.isEmpty) {
+      // 모든 필드가 입력되었으면 완료 페이지로 이동
       navigate(context, route: AppRoute.signUpProfilePicture);
+      return;
     }
-    if (state.currentStep < 10) {
+
+    // 입력되지 않은 필드 중 가장 먼저 나오는 필드로 이동
+    for (int i = 0; i < requiredFieldsOrder.length; i++) {
+      final fieldForStep = requiredFieldsOrder[i];
+      if (unwrittenFields.contains(fieldForStep)) {
+        state = state.copyWith(currentStep: i + 1); // 단계는 1부터 시작
+        return;
+      }
+    }
+
+    // 현재 단계가 마지막 단계가 아니라면 기본적으로 다음 단계로 이동
+    if (state.currentStep < requiredFieldsOrder.length) {
       state = state.copyWith(currentStep: state.currentStep + 1);
+    } else {
+      // 마지막 단계에서 완료 페이지로 이동
+      navigate(context, route: AppRoute.signUpProfilePicture);
     }
   }
 

--- a/lib/features/auth/presentation/widget/sign_up_profile_base_widget.dart
+++ b/lib/features/auth/presentation/widget/sign_up_profile_base_widget.dart
@@ -33,7 +33,7 @@ class _SignUpProfileBaseWidgetState
   Widget buildPage(BuildContext context) {
     final signUpState = ref.watch(signUpProcessProvider);
     final signUpProcess = ref.read(signUpProcessProvider.notifier);
-
+    print(signUpState.unwritten.length);
     return Scaffold(
       appBar: DefaultAppBar(
         title: '프로필 정보',
@@ -45,8 +45,8 @@ class _SignUpProfileBaseWidgetState
           preferredSize: Size.fromHeight(4.h), // Progress bar의 높이를 지정
           child: TweenAnimationBuilder<double>(
             tween: Tween<double>(
-              begin: (signUpState.currentStep - 1) / 10.0,
-              end: signUpState.currentStep / 10.0,
+              begin: (10 - signUpState.unwritten.length - 1) / 10.0,
+              end: (10 - signUpState.unwritten.length) / 10.0,
             ),
             duration: const Duration(milliseconds: 300),
             curve: Curves.easeInOut,
@@ -91,7 +91,7 @@ class _SignUpProfileBaseWidgetState
                       ? () => signUpProcess.nextStep(context)
                       : null,
                   child: Text(
-                    signUpState.currentStep == 10 ? '완료' : '다음',
+                    signUpState.unwritten.isEmpty ? '완료' : '다음',
                     style: Fonts.body01Medium(
                       signUpProcess.isButtonEnabled()
                           ? palette.onPrimary

--- a/lib/features/auth/presentation/widget/sign_up_steps.dart
+++ b/lib/features/auth/presentation/widget/sign_up_steps.dart
@@ -42,11 +42,11 @@ final List<SignUpProfileChoices> signUpSteps = [
   ),
   SignUpProfileChoices(
     question: '지역이 어떻게 되세요?',
-    buildWidget: (signUpNotifier, signUpState) => buildLocationInput(
+    buildWidget: (signUpNotifier, signUpState) => LocationInputWidget(
       selectedLocation: signUpState.selectedLocation,
-      signUpNotifier: signUpNotifier,
-      locationFocusNode: locationFocusNode,
-      locationController: locationController,
+      onLocationUpdated: (location) {
+        signUpNotifier.updateSelectedLocation(location);
+      },
     ),
   ),
   SignUpProfileChoices(


### PR DESCRIPTION
## 📔 요약:
- 회원가입 단계별 진행 상태 및 필드 검증 로직 개선 #26 

## 💬 변경 사유:
- 개발하면서 `reset --hard` 과정에서 소실됐었던 커밋 복구

## 주요 변경 사항:
< `SignUpProcessState` >
- `unwritten` 추가: 입력되지 않은 필드를 반환하는 getter 추가
- 각 단계별 필드 상태 확인 및 진행 가능 여부(isButtonEnabled) 로직 유지
- `selectedHobbies` 초기화 시 빈 배열로 처리
- 나이와 MBTI 완성도 관련 getter 유지

< `SignUpProcessProvider` >
- `nextStep` 로직 강화: 새로 추가된 getter `unwritten`을 사용해 필드 상태에 따라 다음 단계로 이동
- 필요한 필드 순서(`requiredFieldsOrder`)를 정의하고, 입력되지 않은 첫 번째 필드로 자동 이동
- 마지막 단계 완료 시 `signUpProfilePicture` 페이지로 이동
- `reset` 및 각 속성 업데이트 함수들 유지

< `SignUpProfileBaseWidget` >
- `unwritten`의 길이를 기반으로 `LinearProgressIndicator` 진행도 표시 방식 변경
- `unwritten`의 상태에 따라 완료 여부를 실시간으로 반영
- `DefaultElevatedButton` 텍스트를 동적으로 변경(‘다음’ 또는 ‘완료’)

## 🧐 체크리스트:
- 아래 체크리스트를 통해 PR 사항을 최종적으로 점검해 주세요
- [x] 코드의 변경 사유와 목적이 명확하게 기술되었나요?
- [x] 파일, 변수, 주석 등이 컨벤션 규칙에 맞게 준수되었나요?
- [x] 변경된 코드가 기존 기능에 영향을 주지 않도록 설계되었나요?
- [x] 변경된 파일에 대한 문서나 주석이 업데이트 되었나요?