### PR TITLE
프로필 미리보기 페이지 - 프로필 이미지 페이지뷰 적용

### DIFF
--- a/lib/features/my/presentation/page/profile_preview_page.dart
+++ b/lib/features/my/presentation/page/profile_preview_page.dart
@@ -6,6 +6,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shimmer/shimmer.dart';
 
 class ProfilePreviewPage extends StatefulWidget {
   final MyProfile profile;
@@ -64,6 +65,37 @@ class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
                                 fit: BoxFit.cover,
                                 width: double.infinity,
                                 height: context.screenHeight * 0.5,
+                                imageBuilder: (context, imageProvider) {
+                                  // 테스트용 지연
+                                  return FutureBuilder(
+                                    future: Future.delayed(
+                                        const Duration(seconds: 2)),
+                                    builder: (context, snapshot) {
+                                      if (snapshot.connectionState !=
+                                          ConnectionState.done) {
+                                        // 로딩 중에는 placeholder 그대로 보여줌
+                                        return Shimmer.fromColors(
+                                          baseColor: Colors.grey.shade300,
+                                          highlightColor: Colors.white,
+                                          child: Container(
+                                            width: double.infinity,
+                                            height: context.screenHeight * 0.5,
+                                            color: Colors.grey.shade300,
+                                          ),
+                                        );
+                                      }
+                                      // 지연 후 실제 이미지 표시
+                                      return Image(
+                                        image: imageProvider,
+                                        fit: BoxFit.cover,
+                                        width: double.infinity,
+                                        height: context.screenHeight * 0.5,
+                                      );
+                                    },
+                                  );
+                                },
+                                errorWidget: (context, url, error) =>
+                                    const Text('프로필 이미지 불러오기 실패..'),
                               );
                             },
                           ),

--- a/lib/features/my/presentation/page/profile_preview_page.dart
+++ b/lib/features/my/presentation/page/profile_preview_page.dart
@@ -20,7 +20,20 @@ class ProfilePreviewPage extends StatefulWidget {
 }
 
 class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
-  int currentImageNum = 1;
+  int _currentImageIndex = 0;
+  late final PageController _pageController;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController(initialPage: _currentImageIndex);
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -42,6 +55,7 @@ class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
                       children: [
                         Positioned.fill(
                           child: PageView.builder(
+                            controller: _pageController,
                             itemCount: validImages.length,
                             itemBuilder: (context, index) {
                               final image = validImages[index];
@@ -54,7 +68,7 @@ class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
                               );
                             },
                             onPageChanged: (index) => setState(
-                              () => currentImageNum = index + 1,
+                              () => _currentImageIndex = index,
                             ),
                           ),
                         ),
@@ -72,7 +86,11 @@ class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
                                 borderRadius: BorderRadius.circular(12.0),
                               ),
                               child: Text(
-                                '$currentImageNum/${validImages.length}',
+                                '${_currentImageIndex + 1}/${validImages.length}',
+                                style: Fonts.body03Regular().copyWith(
+                                  color: Palette.colorWhite,
+                                  fontWeight: FontWeight.w400,
+                                ),
                               ),
                             ),
                           )

--- a/lib/features/my/presentation/page/profile_preview_page.dart
+++ b/lib/features/my/presentation/page/profile_preview_page.dart
@@ -20,13 +20,12 @@ class ProfilePreviewPage extends StatefulWidget {
 }
 
 class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
-  int _currentImageIndex = 0;
   late final PageController _pageController;
 
   @override
   void initState() {
     super.initState();
-    _pageController = PageController(initialPage: _currentImageIndex);
+    _pageController = PageController(initialPage: 0);
   }
 
   @override
@@ -67,31 +66,40 @@ class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
                                 height: context.screenHeight * 0.5,
                               );
                             },
-                            onPageChanged: (index) => setState(
-                              () => _currentImageIndex = index,
-                            ),
                           ),
                         ),
                         if (validImages.length > 1)
                           Positioned(
                             top: context.screenHeight * 0.4,
                             right: 16,
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 6.0,
-                                vertical: 4.0,
-                              ),
-                              decoration: BoxDecoration(
-                                color: Colors.black.withValues(alpha: 0.6),
-                                borderRadius: BorderRadius.circular(12.0),
-                              ),
-                              child: Text(
-                                '${_currentImageIndex + 1}/${validImages.length}',
-                                style: Fonts.body03Regular().copyWith(
-                                  color: Palette.colorWhite,
-                                  fontWeight: FontWeight.w400,
-                                ),
-                              ),
+                            child: AnimatedBuilder(
+                              animation: _pageController,
+                              builder: (context, child) {
+                                int currentPageIndex = 0;
+                                if (_pageController.hasClients) {
+                                  // page는 double → round()로 정수 변환
+                                  currentPageIndex =
+                                      _pageController.page?.round() ??
+                                          _pageController.initialPage;
+                                }
+                                return Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 6.0,
+                                    vertical: 4.0,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: Colors.black.withValues(alpha: 0.6),
+                                    borderRadius: BorderRadius.circular(12.0),
+                                  ),
+                                  child: Text(
+                                    '${currentPageIndex + 1}/${validImages.length}',
+                                    style: Fonts.body03Regular().copyWith(
+                                      color: Palette.colorWhite,
+                                      fontWeight: FontWeight.w400,
+                                    ),
+                                  ),
+                                );
+                              },
                             ),
                           )
                       ],

--- a/lib/features/my/presentation/page/profile_preview_page.dart
+++ b/lib/features/my/presentation/page/profile_preview_page.dart
@@ -20,11 +20,11 @@ class ProfilePreviewPage extends StatefulWidget {
 }
 
 class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
-  int currentImageIndex = 1;
+  int currentImageNum = 1;
 
   @override
   Widget build(BuildContext context) {
-    final validImges =
+    final validImages =
         widget.profile.profileImages.whereType<MyProfileImage>().toList();
 
     return Scaffold(
@@ -42,9 +42,9 @@ class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
                       children: [
                         Positioned.fill(
                           child: PageView.builder(
-                            itemCount: validImges.length,
+                            itemCount: validImages.length,
                             itemBuilder: (context, index) {
-                              final image = validImges[index];
+                              final image = validImages[index];
 
                               return CachedNetworkImage(
                                 imageUrl: image.imageUrl,
@@ -53,24 +53,26 @@ class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
                                 height: context.screenHeight * 0.5,
                               );
                             },
-                            onPageChanged: (value) => setState(
-                              () => currentImageIndex = value + 1,
+                            onPageChanged: (index) => setState(
+                              () => currentImageNum = index + 1,
                             ),
                           ),
                         ),
-                        if (validImges.length > 1)
+                        if (validImages.length > 1)
                           Positioned(
                             top: context.screenHeight * 0.4,
                             right: 16,
                             child: Container(
                               padding: const EdgeInsets.symmetric(
-                                  horizontal: 6.0, vertical: 4.0),
+                                horizontal: 6.0,
+                                vertical: 4.0,
+                              ),
                               decoration: BoxDecoration(
                                 color: Colors.black.withValues(alpha: 0.6),
                                 borderRadius: BorderRadius.circular(12.0),
                               ),
                               child: Text(
-                                '$currentImageIndex/${validImges.length}',
+                                '$currentImageNum/${validImages.length}',
                               ),
                             ),
                           )

--- a/lib/features/my/presentation/page/profile_preview_page.dart
+++ b/lib/features/my/presentation/page/profile_preview_page.dart
@@ -24,8 +24,9 @@ class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
 
   @override
   Widget build(BuildContext context) {
-    final totalImageCount =
-        widget.profile.profileImages.whereType<MyProfileImage>().length;
+    final validImges =
+        widget.profile.profileImages.whereType<MyProfileImage>().toList();
+
     return Scaffold(
       backgroundColor: Palette.colorWhite,
       body: Stack(
@@ -41,12 +42,12 @@ class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
                       children: [
                         Positioned.fill(
                           child: PageView.builder(
-                            itemCount: totalImageCount,
+                            itemCount: validImges.length,
                             itemBuilder: (context, index) {
-                              final image = widget.profile.profileImages[index];
+                              final image = validImges[index];
 
                               return CachedNetworkImage(
-                                imageUrl: image?.imageUrl ?? '',
+                                imageUrl: image.imageUrl,
                                 fit: BoxFit.cover,
                                 width: double.infinity,
                                 height: context.screenHeight * 0.5,
@@ -57,7 +58,7 @@ class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
                             ),
                           ),
                         ),
-                        if (totalImageCount > 1)
+                        if (validImges.length > 1)
                           Positioned(
                             top: context.screenHeight * 0.4,
                             right: 16,
@@ -69,7 +70,7 @@ class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
                                 borderRadius: BorderRadius.circular(12.0),
                               ),
                               child: Text(
-                                '$currentImageIndex/$totalImageCount',
+                                '$currentImageIndex/${validImges.length}',
                               ),
                             ),
                           )

--- a/lib/features/my/presentation/page/profile_preview_page.dart
+++ b/lib/features/my/presentation/page/profile_preview_page.dart
@@ -1,12 +1,15 @@
 import 'package:atwoz_app/app/constants/constants.dart';
 import 'package:atwoz_app/core/extension/extended_context.dart';
+import 'package:atwoz_app/core/util/util.dart';
 import 'package:atwoz_app/features/my/domain/model/my_profile.dart';
+import 'package:atwoz_app/features/my/my.dart';
 import 'package:atwoz_app/features/profile/presentation/widget/profile_sub_information.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 
-class ProfilePreviewPage extends StatelessWidget {
+class ProfilePreviewPage extends StatefulWidget {
   final MyProfile profile;
 
   const ProfilePreviewPage({
@@ -15,7 +18,16 @@ class ProfilePreviewPage extends StatelessWidget {
   });
 
   @override
+  State<ProfilePreviewPage> createState() => _ProfilePreviewPageState();
+}
+
+class _ProfilePreviewPageState extends State<ProfilePreviewPage> {
+  int currentImageIndex = 1;
+
+  @override
   Widget build(BuildContext context) {
+    final totalImageCount =
+        widget.profile.profileImages.whereType<MyProfileImage>().length;
     return Scaffold(
       backgroundColor: Palette.colorWhite,
       body: Stack(
@@ -27,15 +39,43 @@ class ProfilePreviewPage extends StatelessWidget {
                 child: Stack(
                   children: [
                     /// 배경 이미지
-                    Positioned(
-                      top: 0,
-                      left: 0,
-                      right: 0,
-                      child: Image.network(
-                        profile.profileImages[0]!.imageUrl,
-                        fit: BoxFit.cover,
-                        height: context.screenHeight * 0.5,
-                      ),
+                    Stack(
+                      children: [
+                        Positioned.fill(
+                          child: PageView.builder(
+                            itemCount: totalImageCount,
+                            itemBuilder: (context, index) {
+                              final image = widget.profile.profileImages[index];
+
+                              return CachedNetworkImage(
+                                imageUrl: image?.imageUrl ?? '',
+                                fit: BoxFit.cover,
+                                width: double.infinity,
+                                height: context.screenHeight * 0.5,
+                              );
+                            },
+                            onPageChanged: (value) => setState(
+                              () => currentImageIndex = value + 1,
+                            ),
+                          ),
+                        ),
+                        if (totalImageCount > 1)
+                          Positioned(
+                            top: context.screenHeight * 0.4,
+                            right: 16,
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 6.0, vertical: 4.0),
+                              decoration: BoxDecoration(
+                                color: Colors.black.withValues(alpha: 0.6),
+                                borderRadius: BorderRadius.circular(12.0),
+                              ),
+                              child: Text(
+                                '$currentImageIndex/$totalImageCount',
+                              ),
+                            ),
+                          )
+                      ],
                     ),
 
                     /// 그라디언트
@@ -99,27 +139,27 @@ class ProfilePreviewPage extends StatelessWidget {
                       items: [
                         SubInfoItem(
                           iconPath: IconPath.smoking,
-                          label: profile.smokingStatus.label,
+                          label: widget.profile.smokingStatus.label,
                         ),
                         SubInfoItem(
                           iconPath: IconPath.wineglass,
-                          label: profile.drinkingStatus.label,
+                          label: widget.profile.drinkingStatus.label,
                         ),
                         SubInfoItem(
                           iconPath: IconPath.school,
-                          label: profile.education.label,
+                          label: widget.profile.education.label,
                         ),
                         SubInfoItem(
                           iconPath: IconPath.bless,
-                          label: profile.religion.label,
+                          label: widget.profile.religion.label,
                         ),
                         SubInfoItem(
                           iconPath: IconPath.ruler,
-                          label: '${profile.height}cm',
+                          label: '${widget.profile.height}cm',
                         ),
                         SubInfoItem(
                           iconPath: IconPath.business,
-                          label: profile.job.label,
+                          label: widget.profile.job.label,
                         ),
                       ],
                     ),
@@ -135,7 +175,7 @@ class ProfilePreviewPage extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  '${profile.nickname}, ${profile.age}',
+                  '${widget.profile.nickname}, ${widget.profile.age}',
                   style: Fonts.header02().copyWith(
                     color: Palette.colorBlack,
                     fontWeight: FontWeight.w600,
@@ -143,7 +183,7 @@ class ProfilePreviewPage extends StatelessWidget {
                 ),
                 const Gap(6),
                 Text(
-                  '${profile.mbti} ・ ${profile.region}',
+                  '${widget.profile.mbti} ・ ${widget.profile.region}',
                   style: Fonts.body02Medium().copyWith(
                     color: Palette.colorGrey600,
                     fontWeight: FontWeight.w400,
@@ -151,7 +191,7 @@ class ProfilePreviewPage extends StatelessWidget {
                 ),
                 const Gap(6),
                 Row(
-                  children: profile.hobbies
+                  children: widget.profile.hobbies
                       .map(
                         (hobby) => _MainHobbyBadge(hobby.label),
                       )

--- a/lib/features/my/presentation/page/profile_preview_page.dart
+++ b/lib/features/my/presentation/page/profile_preview_page.dart
@@ -1,7 +1,5 @@
 import 'package:atwoz_app/app/constants/constants.dart';
 import 'package:atwoz_app/core/extension/extended_context.dart';
-import 'package:atwoz_app/core/util/util.dart';
-import 'package:atwoz_app/features/my/domain/model/my_profile.dart';
 import 'package:atwoz_app/features/my/my.dart';
 import 'package:atwoz_app/features/profile/presentation/widget/profile_sub_information.dart';
 import 'package:cached_network_image/cached_network_image.dart';


### PR DESCRIPTION
## 📔 요약:
- 프로필 미리보기 페이지 - 프로필 이미지 페이지뷰 적용

## 💬 변경 사유:
- 대표사진만 조회 -> 전체 이미지 조회로 변경

## 🧐 체크리스트:
- 아래 체크리스트를 통해 PR 사항을 최종적으로 점검해 주세요

- [x] 코드의 변경 사유와 목적이 명확하게 기술되었나요?
- [x] 파일, 변수, 주석 등이 컨벤션 규칙에 맞게 준수되었나요?
- [x] 변경된 코드가 기존 기능에 영향을 주지 않도록 설계되었나요?
- [ ] 변경된 파일에 대한 문서나 주석이 업데이트 되었나요?

## 🙏 비고
- PR과 관련하여 추가적인 내용이 있는 경우 작성해 주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 프로필 미리보기에서 여러 장의 사진을 좌우로 스와이프 가능.
  * 사진이 2장 이상일 때 화면 상단 오른쪽에 현재/전체 사진 수 표시.
  * 이미지 로딩 중 셔머(placeholder) 표시 및 로드 실패 시 에러 표시.

* **개선**
  * 이미지 캐싱 적용으로 로딩 속도 및 전환 부드러움 향상.
  * 흡연·음주·학력·종교·키·직업·닉네임·나이·MBTI·지역·취미 정보가 일관되게 표시되며, 취미는 배지 형태로 렌더링.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->